### PR TITLE
Fix name and column handling for compression

### DIFF
--- a/redcap_bridge/cli.py
+++ b/redcap_bridge/cli.py
@@ -24,8 +24,10 @@ def main(command_line=None):
                           help="The destination filename.")
     download.add_argument("config_json", nargs=1, metavar='config_json', type=str,
                           help="The json configuration file of the project")
-    download.add_argument("--format", type=str, nargs=1, metavar='format',
+    download.add_argument("-f", "--format", type=str, nargs=1, metavar='format',
                           help="Format to store the data (json/csv)")
+    download.add_argument("-c", "--compressed", action='store_true',
+                          help="Compress the output file (use labels and merge checkbox columns)")
 
     # parse arguments
     args = parser.parse_args(command_line)
@@ -33,7 +35,8 @@ def main(command_line=None):
     if args.debug:
         print("debug: " + str(args))
     if args.command == 'download':
-        download_records(args.destination[0], args.config_json[0])
+        download_records(args.destination[0], args.config_json[0], format=args.format[0],
+                         compressed=bool(args.compressed))
 
 
 if __name__ == '__main__':

--- a/redcap_bridge/server_interface.py
+++ b/redcap_bridge/server_interface.py
@@ -243,19 +243,6 @@ def configure_project_settings(server_config_json):
                       f'enable surveys to be able to collect data via the survey URL')
 
 
-def get_redcap_project(server_config_json):
-    """
-    Initialize a pycap project based on the provided server configuration
-    :param server_config_json: json file containing the api_url and api_token
-    :return: pycap project
-    """
-    config = json.load(open(server_config_json, 'r'))
-    if config['api_token'] in os.environ:
-        config['api_token'] = os.environ[config['api_token']]
-    redproj = redcap.Project(config['api_url'], config['api_token'])
-    return redproj
-
-
 def check_external_modules(server_config_json):
     """
     Download records from the redcap server.

--- a/redcap_bridge/server_interface.py
+++ b/redcap_bridge/server_interface.py
@@ -79,9 +79,9 @@ def download_records(save_to, server_config_json, format='csv', compressed=False
     """
 
     if compressed:
-        fixed_params = {'raw_label': 'label',
-                        'raw_label_header': 'label',
-                        'export_checkbox_label': True}
+        fixed_params = {'raw_or_label': 'label',
+                        'raw_or_label_headers': 'label',
+                        'export_checkbox_labels': True}
         for fix_key, fix_value in fixed_params.items():
             if fix_key in kwargs and kwargs[fix_key] != fix_value:
                 warnings.warn(f'`compressed` is overwriting current {fix_key} setting.')
@@ -108,7 +108,7 @@ def download_records(save_to, server_config_json, format='csv', compressed=False
             warnings.warn('Can only compress csv output. Ignoring `compressed` parameter.')
         else:
             # run compression in place
-            compress_record(save_file, save_file)
+            compress_record(save_to, save_to)
 
 
 def upload_records(csv_file, server_config_json):

--- a/redcap_bridge/test_redcap/test_utils.py
+++ b/redcap_bridge/test_redcap/test_utils.py
@@ -35,18 +35,15 @@ def initialize_test_dir(clean=True):
     shutil.copytree(packaged_testfolder, test_directory / 'testfiles')
     return test_directory
 
+
 def test_compressedCSV(initialize_test_dir):
 
     test_dir = test_directory / 'testfiles' / 'compression_test'
 
     compress_record(test_dir / 'original_record.csv', test_dir / 'compressed_record.csv')
-
-
     with open(test_dir / 'compressed_record.csv') as comp_file:
         with open(test_dir / 'expected_record.csv') as exp_file:
             res = comp_file.read()
             exp = exp_file.read()
 
             assert res == exp
-
-

--- a/redcap_bridge/utils.py
+++ b/redcap_bridge/utils.py
@@ -72,7 +72,7 @@ def compress_record(csv_file, compressed_file=None):
     df = pd.read_csv(csv_file, na_filter=False, dtype='str')
 
     # compressing embedded fields
-    embedding_columns = df.filter(regex='.\(choice=.*\{.*\}\)').columns
+    embedding_columns = df.filter(regex=r'.\(choice=.*\{.*\}\)').columns
     embedded_indexes = df.columns.get_indexer(embedding_columns)
     # ensure header of next columns are empty
     assert all([c.startswith('Unnamed: ') for c in df.columns[embedded_indexes + 1]])
@@ -86,9 +86,9 @@ def compress_record(csv_file, compressed_file=None):
         return ', '.join([v for v in values if v != ''])
 
     # merge multi-column fields
-    names = set([c.split(' (choice=')[0] for c in df.filter(regex='. \(choice=.*\)').columns])
+    names = set([c.split(' (choice=')[0] for c in df.filter(regex=r'. \(choice=.*\)').columns])
     for name in names:
-        sub_columns = df.filter(regex=f'^{name} \(choice=.').columns
+        sub_columns = df.filter(regex=rf'^{name} \(choice=.').columns
         sub_indexes = df.columns.get_indexer(sub_columns)
         # insert column with merged columns
         df.insert(loc=int(sub_indexes[0]),
@@ -101,4 +101,3 @@ def compress_record(csv_file, compressed_file=None):
         return df
     else:
         df.to_csv(compressed_file, index=False)
-

--- a/redcap_bridge/utils.py
+++ b/redcap_bridge/utils.py
@@ -88,7 +88,19 @@ def compress_record(csv_file, compressed_file=None):
     # merge multi-column fields
     names = set([c.split(' (choice=')[0] for c in df.filter(regex='. \(choice=.*\)').columns])
     for name in names:
-        sub_columns = df.filter(regex=f'^{name} \(choice=.').columns
+
+        if name in df.columns:
+            warnings.warn(f'Can not compress columns with name {name}. '
+                          f'Output column already exists.')
+            continue
+
+        # inactivate metacharacters of regex
+        metachars = '.^$*+?{}[]\|()'
+        regex_name = name
+        for metachar in metachars:
+            regex_name = regex_name.replace(metachar, '\\' +metachar)
+        # identify relevant columns to be merged
+        sub_columns = df.filter(regex=f'^{regex_name} \(choice=.').columns
         sub_indexes = df.columns.get_indexer(sub_columns)
         # insert column with merged columns
         df.insert(loc=int(sub_indexes[0]),


### PR DESCRIPTION
This PR mainly fixes two bugs in compress_record
- avoid interpretation of characters of a column name as regular expression
- avoid overwriting an existing column if the column name is already in use

Additionally this PR adds support for
- compression via the CLI
- correctly calling the compress_record function
- code cleanup

@killianrochet What do you think?